### PR TITLE
Add sentiment analysis MCP server implementation

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,37 @@
+import json
+import gradio as gr
+from textblob import TextBlob
+
+def sentiment_analysis(text: str) -> str:
+    """
+    Analyze the sentiment of the given text.
+
+    Args:
+        text (str): The text to analyze
+
+    Returns:
+        str: A JSON string containing polarity, subjectivity, and assessment
+    """
+    blob = TextBlob(text)
+    sentiment = blob.sentiment
+    
+    result = {
+        "polarity": round(sentiment.polarity, 2),  # -1 (negative) to 1 (positive)
+        "subjectivity": round(sentiment.subjectivity, 2),  # 0 (objective) to 1 (subjective)
+        "assessment": "positive" if sentiment.polarity > 0 else "negative" if sentiment.polarity < 0 else "neutral"
+    }
+
+    return json.dumps(result)
+
+# Create the Gradio interface
+demo = gr.Interface(
+    fn=sentiment_analysis,
+    inputs=gr.Textbox(placeholder="Enter text to analyze..."),
+    outputs=gr.Textbox(),  # Changed from gr.JSON() to gr.Textbox()
+    title="Text Sentiment Analysis",
+    description="Analyze the sentiment of text using TextBlob"
+)
+
+# Launch the interface and MCP server
+if __name__ == "__main__":
+    demo.launch(mcp_server=True)

--- a/my-agent/agent.json
+++ b/my-agent/agent.json
@@ -7,7 +7,7 @@
             "command": "npx",
             "args": [
                 "mcp-remote",
-                "https://abidlabs-mcp-tool-http.hf.space/gradio_api/mcp/sse"
+                "http://localhost:7860/gradio_api/mcp/sse"
             ]
         }
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ gradio[mcp]
 smolagents[mcp]
 mcp
 fastmcp
+textblob


### PR DESCRIPTION
## Summary

This PR implements the missing Tutorial 1 from the MCP course materials by adding a complete sentiment analysis MCP server using Gradio and TextBlob.

## What This Adds

### New Files
- **** - Complete sentiment analysis MCP server implementation
- **Updated ** - Added TextBlob dependency
- **Updated ** - Now connects to local sentiment analysis server

### Features
- Web interface at  for testing sentiment analysis
- MCP server endpoint at 
- Returns structured sentiment data:
  - Polarity: -1 (negative) to 1 (positive)
  - Subjectivity: 0 (objective) to 1 (subjective)
  - Assessment: "positive", "negative", or "neutral"

## How to Use

### 1. Start the MCP Server
```bash
python mcp_server.py
```

### 2. Test with Tiny Agent
```bash
cd my-agent
tiny-agents run agent.json
```

### 3. Try Sentiment Analysis
```
» Analyze the sentiment of "I love this new feature!"
```

## Why This Was Needed

The original implementation was missing the actual sentiment analysis MCP server that the tutorial references. This completes the end-to-end MCP workflow:

1. ✅ **Tutorial 1**: MCP Server with sentiment analysis (this PR)
2. ✅ **Tutorial 2**: MCP Client (existing )
3. ✅ **Tutorial 3**: Tiny Agents connecting to YOUR server

## Testing

- [x] MCP server starts successfully
- [x] Web interface works for manual testing
- [x] MCP schema is properly exposed
- [x] Tiny agent can discover and use the sentiment analysis tool
- [x] Returns proper JSON-formatted results

This completes the tutorial implementation and enables the tiny agent to actually use a real sentiment analysis MCP tool instead of relying on code generation.